### PR TITLE
chore: drop support for Node.js prior to 8.0.0

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [0.10.x, 0.12.x, 4.x, 6.x, 8.x, 10.x, 12.x, 14.x, 15.x]
+        node-version: [8.x, 10.x, 12.x, 14.x, 15.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "main": "clockdrift.js",
   "engines": {
-    "node": "0.10"
+    "node": ">=8.0.0"
   },
   "keywords": [],
   "preferGlobal": true,


### PR DESCRIPTION
BREAKING CHANGE: drop support for Node.js prior to 8.0.0